### PR TITLE
Fix AttachmentCipherInputStream for small reads

### DIFF
--- a/java/src/main/java/org/whispersystems/signalservice/api/crypto/AttachmentCipherInputStream.java
+++ b/java/src/main/java/org/whispersystems/signalservice/api/crypto/AttachmentCipherInputStream.java
@@ -96,8 +96,28 @@ public class AttachmentCipherInputStream extends FileInputStream {
 
   @Override
   public int read(byte[] buffer, int offset, int length) throws IOException {
-    if      (totalRead != totalDataSize) return readIncremental(buffer, offset, length);
-    else if (!done)                      return readFinal(buffer, offset, length);
+    int readLength = 0;
+    if (null != overflowBuffer) {
+      if (overflowBuffer.length > length) {
+        System.arraycopy(overflowBuffer, 0, buffer, offset, length);
+        overflowBuffer = Arrays.copyOfRange(overflowBuffer, length, overflowBuffer.length);
+        return length;
+      } else if (overflowBuffer.length == length) {
+        System.arraycopy(overflowBuffer, 0, buffer, offset, length);
+        overflowBuffer = null;
+        return length;
+      } else {
+        System.arraycopy(overflowBuffer, 0, buffer, offset, overflowBuffer.length);
+        readLength += overflowBuffer.length;
+        offset += readLength;
+        length -= readLength;
+        overflowBuffer = null;
+      }
+    }
+
+    if      (totalRead != totalDataSize) return readLength + readIncremental(buffer, offset, length);
+    else if (!done)                      return readLength + readFinal(buffer, offset, length);
+    else if (readLength > 0)             return readLength;
     else                                 return -1;
   }
 
@@ -121,35 +141,30 @@ public class AttachmentCipherInputStream extends FileInputStream {
 
   private int readFinal(byte[] buffer, int offset, int length) throws IOException {
     try {
-      int flourish = cipher.doFinal(buffer, offset);
+      int outputLen = cipher.getOutputSize(0);
 
+      if (outputLen <= length) {
+        done = true;
+        return cipher.doFinal(buffer, offset);
+      }
+
+      byte[] transientBuffer = new byte[outputLen];
+      outputLen = cipher.doFinal(transientBuffer, 0);
       done = true;
-      return flourish;
+      if (outputLen <= length) {
+        System.arraycopy(transientBuffer, 0, buffer, offset, outputLen);
+        return outputLen;
+      } else {
+        System.arraycopy(transientBuffer, 0, buffer, offset, length);
+        overflowBuffer = Arrays.copyOfRange(transientBuffer, length, outputLen);
+        return length;
+      }
     } catch (IllegalBlockSizeException | BadPaddingException | ShortBufferException e) {
       throw new IOException(e);
     }
   }
 
   private int readIncremental(byte[] buffer, int offset, int length) throws IOException {
-    int readLength = 0;
-    if (null != overflowBuffer) {
-      if (overflowBuffer.length > length) {
-        System.arraycopy(overflowBuffer, 0, buffer, offset, length);
-        overflowBuffer = Arrays.copyOfRange(overflowBuffer, length, overflowBuffer.length);
-        return length;
-      } else if (overflowBuffer.length == length) {
-        System.arraycopy(overflowBuffer, 0, buffer, offset, length);
-        overflowBuffer = null;
-        return length;
-      } else {
-        System.arraycopy(overflowBuffer, 0, buffer, offset, overflowBuffer.length);
-        readLength += overflowBuffer.length;
-        offset += readLength;
-        length -= readLength;
-        overflowBuffer = null;
-      }
-    }
-
     if (length + totalRead > totalDataSize)
       length = (int)(totalDataSize - totalRead);
 
@@ -161,21 +176,19 @@ public class AttachmentCipherInputStream extends FileInputStream {
       int outputLen = cipher.getOutputSize(read);
 
       if (outputLen <= length) {
-        readLength += cipher.update(internalBuffer, 0, read, buffer, offset);
-        return readLength;
+        return cipher.update(internalBuffer, 0, read, buffer, offset);
       }
 
       byte[] transientBuffer = new byte[outputLen];
       outputLen = cipher.update(internalBuffer, 0, read, transientBuffer, 0);
       if (outputLen <= length) {
         System.arraycopy(transientBuffer, 0, buffer, offset, outputLen);
-        readLength += outputLen;
+        return outputLen;
       } else {
         System.arraycopy(transientBuffer, 0, buffer, offset, length);
         overflowBuffer = Arrays.copyOfRange(transientBuffer, length, outputLen);
-        readLength += length;
+        return length;
       }
-      return readLength;
     } catch (ShortBufferException e) {
       throw new AssertionError(e);
     }

--- a/java/src/main/java/org/whispersystems/signalservice/api/crypto/AttachmentCipherInputStream.java
+++ b/java/src/main/java/org/whispersystems/signalservice/api/crypto/AttachmentCipherInputStream.java
@@ -89,6 +89,21 @@ public class AttachmentCipherInputStream extends FileInputStream {
     }
   }
 
+  private static int toUnsignedInt(byte b) {
+    return ((int)b) & 0xFF;
+  }
+
+  @Override
+  public int read() throws IOException {
+    byte[] buffer = new byte[1];
+
+    int read;
+    while ((read = read(buffer)) == 0) { }
+
+    if (read == -1) return -1;
+    else            return toUnsignedInt(buffer[0]);
+  }
+
   @Override
   public int read(byte[] buffer) throws IOException {
     return read(buffer, 0, buffer.length);


### PR DESCRIPTION
When the buffer given to read is smaller than the final block, ShortBufferException was thrown.
Fixed, by storing the remaining bytes in overflowBuffer in the readFinal method.

Also implement the read() method (reads single byte) for AttachmentCipherInputStream. Otherwise the read() method is inherited from FileInputStream and returns encrypted data.
