### PR TITLE
Detect end of stream in DeviceContact/DeviceGroupInputStream.read()

### DIFF
--- a/java/src/main/java/org/whispersystems/signalservice/api/messages/multidevice/ChunkedInputStream.java
+++ b/java/src/main/java/org/whispersystems/signalservice/api/messages/multidevice/ChunkedInputStream.java
@@ -13,7 +13,11 @@ public class ChunkedInputStream {
   }
 
   protected int readRawVarint32() throws IOException {
-    byte tmp = (byte)in.read();
+    int tmpInt = in.read();
+    if (tmpInt == -1) {
+      return -1;
+    }
+    byte tmp = (byte)tmpInt;
     if (tmp >= 0) {
       return tmp;
     }

--- a/java/src/main/java/org/whispersystems/signalservice/api/messages/multidevice/DeviceContactsInputStream.java
+++ b/java/src/main/java/org/whispersystems/signalservice/api/messages/multidevice/DeviceContactsInputStream.java
@@ -15,8 +15,11 @@ public class DeviceContactsInputStream extends ChunkedInputStream {
   }
 
   public DeviceContact read() throws IOException {
-    long   detailsLength     = readRawVarint32();
-    byte[] detailsSerialized = new byte[(int)detailsLength];
+    int detailsLength = readRawVarint32();
+    if (detailsLength == -1) {
+      return null;
+    }
+    byte[] detailsSerialized = new byte[detailsLength];
     Util.readFully(in, detailsSerialized);
 
     SignalServiceProtos.ContactDetails      details = SignalServiceProtos.ContactDetails.parseFrom(detailsSerialized);

--- a/java/src/main/java/org/whispersystems/signalservice/api/messages/multidevice/DeviceGroupsInputStream.java
+++ b/java/src/main/java/org/whispersystems/signalservice/api/messages/multidevice/DeviceGroupsInputStream.java
@@ -16,8 +16,11 @@ public class DeviceGroupsInputStream extends ChunkedInputStream{
   }
 
   public DeviceGroup read() throws IOException {
-    long   detailsLength     = readRawVarint32();
-    byte[] detailsSerialized = new byte[(int)detailsLength];
+    int detailsLength = readRawVarint32();
+    if (detailsLength == -1) {
+      return null;
+    }
+    byte[] detailsSerialized = new byte[detailsLength];
     Util.readFully(in, detailsSerialized);
 
     SignalServiceProtos.GroupDetails details = SignalServiceProtos.GroupDetails.parseFrom(detailsSerialized);


### PR DESCRIPTION
Adapt ChunkedInputStream.readRawVarint32() to return -1 if the end of the stream has been reached.

Make the read() method of DeviceGroupsInputStream and DeviceContactsInputStream return null if the end of the stream has been reached.
