### PR TITLE
Add an alarm, to wake the WebSocketConnection

### DIFF
--- a/android/src/main/java/org/whispersystems/signalservice/api/WebSocketAlarm.java
+++ b/android/src/main/java/org/whispersystems/signalservice/api/WebSocketAlarm.java
@@ -1,0 +1,71 @@
+package org.whispersystems.signalservice.api;
+
+import android.util.Log;
+
+import android.app.AlarmManager;
+import android.app.PendingIntent;
+import android.content.Intent;
+import android.content.Context;
+import android.content.BroadcastReceiver;
+import android.content.IntentFilter;
+import android.os.SystemClock;
+
+import org.whispersystems.signalservice.internal.websocket.WebSocketConnection;
+
+import java.util.concurrent.TimeUnit;
+
+public class WebSocketAlarm {
+  private static final String TAG = WebSocketAlarm.class.getSimpleName();
+
+  private AlarmReceiver alarmReceiver;
+  private Context context;
+
+  public WebSocketAlarm(Context context) {
+    this.context = context;
+
+    alarmReceiver = new WebSocketAlarm.AlarmReceiver();
+    alarmReceiver.setOrCancelAlarm(true);
+
+    context.registerReceiver(alarmReceiver,
+                             new IntentFilter(AlarmReceiver.WAKE_UP_THREADS_ACTION));
+  }
+
+  public void disable() {
+    alarmReceiver.setOrCancelAlarm(false);
+    context.unregisterReceiver(alarmReceiver);
+
+    alarmReceiver = null;
+    context = null;
+  }
+
+  private class AlarmReceiver extends BroadcastReceiver {
+    private static final int    WAKE_UP_TIMEOUT_SECONDS = 60;
+    private static final String WAKE_UP_THREADS_ACTION = "org.whispersystems.signalservice.api.WebSocketAlarm.AlarmReceiver.WAKE_UP_THREADS";
+
+    private void setOrCancelAlarm(boolean set) {
+      final Intent        intent        = new Intent(WAKE_UP_THREADS_ACTION);
+      final PendingIntent pendingIntent = PendingIntent.getBroadcast(context, 0, intent, 0);
+      final AlarmManager  alarmManager  = (AlarmManager)context.getSystemService(Context.ALARM_SERVICE);
+
+      alarmManager.cancel(pendingIntent);
+
+      if (set) {
+        Log.w(TAG, "Setting repeating alarm to wake up the websocket.");
+
+        alarmManager.setRepeating(AlarmManager.ELAPSED_REALTIME_WAKEUP,
+                                  SystemClock.elapsedRealtime() + TimeUnit.SECONDS.toMillis(WAKE_UP_TIMEOUT_SECONDS),
+                                  TimeUnit.SECONDS.toMillis(WAKE_UP_TIMEOUT_SECONDS),
+                                  pendingIntent);
+      } else {
+        Log.w(TAG, "Canceling websocket wake-up alarm.");
+      }
+    }
+
+    @Override
+    public void onReceive(Context context, Intent intent) {
+      Log.w(TAG, "Waking up the websocket.");
+
+      WebSocketConnection.Alarm.trigger();
+    }
+  }
+}


### PR DESCRIPTION
Adds a way to periodically wake the WebSocketConnection and avoid
issues when the device enters sleep, disrupting timing functions like
Thread.sleep() and Object.wait().

// FREEBIE

### Description

This is a reimplementation of #45, so please see the discussion there, as well as in WhisperSystems/Signal-Android#6644 and WhisperSystems/Signal-Android#6732, for more details.

This started out as an attempt at a different implementation, more aligned with the desired goal of maintaining the existing interface for the `WebSocketConnection`.  I didn't see how that was possible, but I was hoping to find some way using the `libsignal-service-android` artifact, which is currently empty.  Sadly, the current PR turned out mostly the same as #45.

The basic difference, is that the code that sets up the periodic alarm, now resides in the `libsignal-service-android` artifact, in the form of the `WebSocketAlarm` class.  Although it would be preferable, to make this part of `WebSocketConnection`, I don't see how that is possible as `libsignal-service-java`, depends on neither `libsignal-service-android`, nor on any Android-related stuff.  The only way I can see around this, would be to migrate `WebSocketConnection`, along with other classes, that depend on it, to the `libsignal-service-android` artifact, but that would be an unnecessary major-scale modification, I would prefer to avoid.

Even worse, the code that uses `WebSocketConnection`, namely `MessageRetrievalService`, needs to know about the need to use the `WebSocketAlarm` class, and explicitly use it, if necessary.  Again, it would be desirable for the `WebSocketConnection` to take care of itself, but I don't see how that is possible as it doesn't have access to `TextSecurePreferences` and hence knowledge of whether GCM is disabled and neither does it have access to a `Context`, that it can use to set up the alarm.

I apologize in advance for submitting a patch, while acknowledging that it basically has the same shortcomings as the previously submitted PRs.  As I've said, I can't see how the desired approach is possible, at least as far as I understand it, but I thought I'd give it another go, as there are now three separate parties submitting PRs on this, which implies it might be important to many people.  Although I don't think the effort succeeded, I'm submitting it, in case it proves useful to someone.  Feel free to close this without further explanation.