### PR TITLE
Replacing Thread.sleep with an interface to allow other implementations

### DIFF
--- a/java/src/main/java/org/whispersystems/signalservice/api/SignalServiceMessageReceiver.java
+++ b/java/src/main/java/org/whispersystems/signalservice/api/SignalServiceMessageReceiver.java
@@ -16,11 +16,13 @@ import org.whispersystems.signalservice.api.messages.SignalServiceEnvelope;
 import org.whispersystems.signalservice.api.push.SignalServiceAddress;
 import org.whispersystems.signalservice.api.profiles.SignalServiceProfile;
 import org.whispersystems.signalservice.api.util.CredentialsProvider;
+import org.whispersystems.signalservice.api.util.SignalThread;
 import org.whispersystems.signalservice.api.websocket.ConnectivityListener;
 import org.whispersystems.signalservice.internal.configuration.SignalServiceConfiguration;
 import org.whispersystems.signalservice.internal.push.PushServiceSocket;
 import org.whispersystems.signalservice.internal.push.SignalServiceEnvelopeEntity;
 import org.whispersystems.signalservice.internal.configuration.SignalServiceUrl;
+import org.whispersystems.signalservice.internal.util.JavaThread;
 import org.whispersystems.signalservice.internal.util.StaticCredentialsProvider;
 import org.whispersystems.signalservice.internal.websocket.WebSocketConnection;
 import org.whispersystems.signalservice.internal.websocket.WebSocketEventListener;
@@ -44,6 +46,7 @@ public class SignalServiceMessageReceiver {
   private final CredentialsProvider        credentialsProvider;
   private final String                     userAgent;
   private final ConnectivityListener       connectivityListener;
+  private SignalThread                     signalThread;
 
   /**
    * Construct a SignalServiceMessageReceiver.
@@ -59,6 +62,17 @@ public class SignalServiceMessageReceiver {
                                       ConnectivityListener listener)
   {
     this(urls, new StaticCredentialsProvider(user, password, signalingKey), userAgent, listener);
+  }
+
+  public void setSignalThread(org.whispersystems.signalservice.api.util.SignalThread signalThread) {
+    this.signalThread = signalThread;
+  }
+
+  public SignalThread getSignalThread() {
+    if (signalThread==null){
+      signalThread=new JavaThread();
+    }
+    return signalThread;
   }
 
   /**
@@ -137,7 +151,8 @@ public class SignalServiceMessageReceiver {
   public SignalServiceMessagePipe createMessagePipe() {
     WebSocketConnection webSocket = new WebSocketConnection(urls.getSignalServiceUrls()[0].getUrl(),
                                                             urls.getSignalServiceUrls()[0].getTrustStore(),
-                                                            credentialsProvider, userAgent, connectivityListener);
+                                                            credentialsProvider, userAgent, connectivityListener,
+                                                            getSignalThread());
 
     return new SignalServiceMessagePipe(webSocket, credentialsProvider);
   }

--- a/java/src/main/java/org/whispersystems/signalservice/api/util/SignalThread.java
+++ b/java/src/main/java/org/whispersystems/signalservice/api/util/SignalThread.java
@@ -1,0 +1,5 @@
+package org.whispersystems.signalservice.api.util;
+
+public interface SignalThread {
+    public void sleep(long millis) throws InterruptedException;
+}

--- a/java/src/main/java/org/whispersystems/signalservice/internal/util/JavaThread.java
+++ b/java/src/main/java/org/whispersystems/signalservice/internal/util/JavaThread.java
@@ -1,0 +1,10 @@
+package org.whispersystems.signalservice.internal.util;
+
+import org.whispersystems.signalservice.api.util.SignalThread;
+
+public class JavaThread implements SignalThread{
+    @Override
+    public void sleep(long millis) throws InterruptedException {
+        Thread.sleep(millis);
+    }
+}

--- a/java/src/main/java/org/whispersystems/signalservice/internal/websocket/WebSocketConnection.java
+++ b/java/src/main/java/org/whispersystems/signalservice/internal/websocket/WebSocketConnection.java
@@ -6,6 +6,7 @@ import org.whispersystems.libsignal.logging.Log;
 import org.whispersystems.libsignal.util.Pair;
 import org.whispersystems.signalservice.api.push.TrustStore;
 import org.whispersystems.signalservice.api.util.CredentialsProvider;
+import org.whispersystems.signalservice.api.util.SignalThread;
 import org.whispersystems.signalservice.api.websocket.ConnectivityListener;
 import org.whispersystems.signalservice.internal.util.BlacklistingTrustManager;
 import org.whispersystems.signalservice.internal.util.Util;
@@ -57,8 +58,9 @@ public class WebSocketConnection extends WebSocketListener {
   private KeepAliveSender     keepAliveSender;
   private int                 attempts;
   private boolean             connected;
+  private SignalThread        signalThread;
 
-  public WebSocketConnection(String httpUri, TrustStore trustStore, CredentialsProvider credentialsProvider, String userAgent, ConnectivityListener listener) {
+  public WebSocketConnection(String httpUri, TrustStore trustStore, CredentialsProvider credentialsProvider, String userAgent, ConnectivityListener listener, SignalThread signalThread) {
     this.trustStore          = trustStore;
     this.credentialsProvider = credentialsProvider;
     this.userAgent           = userAgent;
@@ -67,6 +69,7 @@ public class WebSocketConnection extends WebSocketListener {
     this.connected           = false;
     this.wsUri               = httpUri.replace("https://", "wss://")
                                       .replace("http://", "ws://") + "/v1/websocket/?login=%s&password=%s";
+    this.signalThread = signalThread;
   }
 
   public synchronized void connect() {
@@ -297,7 +300,7 @@ public class WebSocketConnection extends WebSocketListener {
     public void run() {
       while (!stop.get()) {
         try {
-          Thread.sleep(TimeUnit.SECONDS.toMillis(KEEPALIVE_TIMEOUT_SECONDS));
+          signalThread.sleep(TimeUnit.SECONDS.toMillis(KEEPALIVE_TIMEOUT_SECONDS));
 
           Log.w(TAG, "Sending keep alive...");
           sendKeepAlive();


### PR DESCRIPTION
This replaces the call to Thread.sleep() with an Interface to allow platform dependent implementations for sleeping. This is necessary because sleep does not work on Android so we need to reimplement it based on AlarmManager.

// FREEBIE
# Description
 
This is yet another attempt to solve one of the issues that occur when using Signal on Android without gcm. The problem is that Thread.sleep() on Android may never return and therefore the KeepAlive isn't sent in time, which leads to many problems like discribed in WhisperSystems/Signal-Android#6732 and several other places. (Battery issues, delayed messages etc.)

This is an alternative implementation to #51 @dpapavas has submitted several days ago. I think (or at least I hope), that my implementation meets the requirements better @moxie0 specified. This here is one part of the solution, the other part can be found in https://github.com/theBoatman/Signal-Android - I will create a pull request for that if I get positive feedback on this one.

I think I meet all requirements except one: The Android implementation of SignalThread resides in Signal-Android and not here in libsignal-service-java. I tried to put it here, but I was not able to reference it in SignalAndroid, although libsignal compiled without error. But I think that is a minor change for someone who has a clue of gradle dependencies.

@moxie0 Please give feedback whether this is the way you want this solved and if it has a chance to get merged. 