### PR TITLE
Add functionality to send websocket keep-alives based on real time

### DIFF
--- a/android/src/main/java/org/whispersystems/signalservice/api/util/RealtimeSleepTimer.java
+++ b/android/src/main/java/org/whispersystems/signalservice/api/util/RealtimeSleepTimer.java
@@ -37,15 +37,14 @@ public class RealtimeSleepTimer implements SleepTimer {
 
     alarmReceiver.setAlarm(millis);
 
-    synchronized(this) {
-      wait();
+    synchronized (this) {
+      wait(millis);
     }
 
     context.unregisterReceiver(alarmReceiver);
   }
 
   private class AlarmReceiver extends BroadcastReceiver {
-    private static final int    WAKE_UP_TIMEOUT_SECONDS = 60;
     private static final String WAKE_UP_THREAD_ACTION = "org.whispersystems.signalservice.api.util.RealtimeSleepTimer.AlarmReceiver.WAKE_UP_THREAD";
 
     private void setAlarm(long millis) {
@@ -53,7 +52,7 @@ public class RealtimeSleepTimer implements SleepTimer {
       final PendingIntent pendingIntent = PendingIntent.getBroadcast(context, 0, intent, 0);
       final AlarmManager  alarmManager  = (AlarmManager)context.getSystemService(Context.ALARM_SERVICE);
 
-      Log.w(TAG, "Setting alarm to wake up.");
+      Log.w(TAG, "Setting alarm to wake up in " + millis + "ms.");
 
       if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
         alarmManager.setExactAndAllowWhileIdle(AlarmManager.ELAPSED_REALTIME_WAKEUP,
@@ -74,7 +73,7 @@ public class RealtimeSleepTimer implements SleepTimer {
     public void onReceive(Context context, Intent intent) {
       Log.w(TAG, "Waking up.");
 
-      synchronized(RealtimeSleepTimer.this) {
+      synchronized (RealtimeSleepTimer.this) {
         RealtimeSleepTimer.this.notifyAll();
       }
     }

--- a/android/src/main/java/org/whispersystems/signalservice/api/util/RealtimeSleepTimer.java
+++ b/android/src/main/java/org/whispersystems/signalservice/api/util/RealtimeSleepTimer.java
@@ -1,0 +1,83 @@
+package org.whispersystems.signalservice.api.util;
+
+import android.app.AlarmManager;
+import android.app.PendingIntent;
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+import android.content.IntentFilter;
+import android.os.Build;
+import android.os.SystemClock;
+import android.util.Log;
+
+import org.whispersystems.signalservice.api.util.SleepTimer;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * A sleep timer that is based on elapsed realtime, so
+ * that it works properly, even in low-power sleep modes.
+ *
+ */
+public class RealtimeSleepTimer implements SleepTimer {
+  private static final String TAG = RealtimeSleepTimer.class.getSimpleName();
+
+  private final AlarmReceiver alarmReceiver;
+  private final Context context;
+
+  public RealtimeSleepTimer(Context context) {
+    this.context = context;
+    alarmReceiver = new RealtimeSleepTimer.AlarmReceiver();
+  }
+
+  @Override
+  public void sleep(long millis) throws InterruptedException {
+    context.registerReceiver(alarmReceiver,
+                             new IntentFilter(AlarmReceiver.WAKE_UP_THREAD_ACTION));
+
+    alarmReceiver.setAlarm(millis);
+
+    synchronized(this) {
+      wait();
+    }
+
+    context.unregisterReceiver(alarmReceiver);
+  }
+
+  private class AlarmReceiver extends BroadcastReceiver {
+    private static final int    WAKE_UP_TIMEOUT_SECONDS = 60;
+    private static final String WAKE_UP_THREAD_ACTION = "org.whispersystems.signalservice.api.util.RealtimeSleepTimer.AlarmReceiver.WAKE_UP_THREAD";
+
+    private void setAlarm(long millis) {
+      final Intent        intent        = new Intent(WAKE_UP_THREAD_ACTION);
+      final PendingIntent pendingIntent = PendingIntent.getBroadcast(context, 0, intent, 0);
+      final AlarmManager  alarmManager  = (AlarmManager)context.getSystemService(Context.ALARM_SERVICE);
+
+      Log.w(TAG, "Setting alarm to wake up.");
+
+      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+        alarmManager.setExactAndAllowWhileIdle(AlarmManager.ELAPSED_REALTIME_WAKEUP,
+                                               SystemClock.elapsedRealtime() + millis,
+                                               pendingIntent);
+      } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
+        alarmManager.setExact(AlarmManager.ELAPSED_REALTIME_WAKEUP,
+                              SystemClock.elapsedRealtime() + millis,
+                              pendingIntent);
+      } else {
+        alarmManager.set(AlarmManager.ELAPSED_REALTIME_WAKEUP,
+                         SystemClock.elapsedRealtime() + millis,
+                         pendingIntent);
+      }
+    }
+
+    @Override
+    public void onReceive(Context context, Intent intent) {
+      Log.w(TAG, "Waking up.");
+
+      synchronized(RealtimeSleepTimer.this) {
+        RealtimeSleepTimer.this.notifyAll();
+      }
+    }
+  }
+}
+

--- a/android/src/main/java/org/whispersystems/signalservice/api/util/RealtimeSleepTimer.java
+++ b/android/src/main/java/org/whispersystems/signalservice/api/util/RealtimeSleepTimer.java
@@ -31,14 +31,21 @@ public class RealtimeSleepTimer implements SleepTimer {
   }
 
   @Override
-  public void sleep(long millis) throws InterruptedException {
+  public void sleep(long millis) {
     context.registerReceiver(alarmReceiver,
                              new IntentFilter(AlarmReceiver.WAKE_UP_THREAD_ACTION));
 
+    final long startTime = System.currentTimeMillis();
     alarmReceiver.setAlarm(millis);
 
-    synchronized (this) {
-      wait(millis);
+    while (System.currentTimeMillis() - startTime < millis) {
+        try {
+          synchronized (this) {
+            wait(millis - System.currentTimeMillis() + startTime);
+          }
+        } catch (InterruptedException e) {
+          Log.w(TAG, e);
+        }
     }
 
     context.unregisterReceiver(alarmReceiver);

--- a/java/src/main/java/org/whispersystems/signalservice/api/util/SleepTimer.java
+++ b/java/src/main/java/org/whispersystems/signalservice/api/util/SleepTimer.java
@@ -1,0 +1,5 @@
+package org.whispersystems.signalservice.api.util;
+
+public interface SleepTimer {
+  public void sleep(long millis) throws InterruptedException;
+}

--- a/java/src/main/java/org/whispersystems/signalservice/api/util/UptimeSleepTimer.java
+++ b/java/src/main/java/org/whispersystems/signalservice/api/util/UptimeSleepTimer.java
@@ -1,0 +1,16 @@
+package org.whispersystems.signalservice.api.util;
+
+import org.whispersystems.signalservice.api.util.SleepTimer;
+
+/**
+ * A simle sleep timer.  Since Thread.sleep is based on uptime
+ * this will not work properly in low-power sleep modes, when
+ * the CPU is suspended and uptime does not elapse.
+ *
+ */
+public class UptimeSleepTimer implements SleepTimer {
+  @Override
+  public void sleep(long millis) throws InterruptedException {
+    Thread.sleep(millis);
+  }
+}

--- a/java/src/main/java/org/whispersystems/signalservice/internal/websocket/WebSocketConnection.java
+++ b/java/src/main/java/org/whispersystems/signalservice/internal/websocket/WebSocketConnection.java
@@ -304,21 +304,11 @@ public class WebSocketConnection extends WebSocketListener {
     private AtomicBoolean stop = new AtomicBoolean(false);
 
     public void run() {
-      final long timeoutMillis = TimeUnit.SECONDS.toMillis(KEEPALIVE_TIMEOUT_SECONDS);
-
       while (!stop.get()) {
-        final long startTime = System.currentTimeMillis();
-
-        while (elapsedTime(startTime) < timeoutMillis) {
-          try {
-            sleepTimer.sleep(timeoutMillis - elapsedTime(startTime));
-          } catch (Throwable e) {
-            Log.w(TAG, e);
-          }
-        }
-
-        Log.w(TAG, "Sending keep alive...");
         try {
+          sleepTimer.sleep(TimeUnit.SECONDS.toMillis(KEEPALIVE_TIMEOUT_SECONDS));
+
+          Log.w(TAG, "Sending keep alive...");
           sendKeepAlive();
         } catch (Throwable e) {
           Log.w(TAG, e);


### PR DESCRIPTION
Adds a couple of classes, that allow sleeping based on real time and
uptime and allows specification of the keep-alive timing method used
by the WebSocketConnection.

// FREEBIE

### Description

See #45 and #51, as well as in WhisperSystems/Signal-Android#6644 and WhisperSystems/Signal-Android#6732, for more details.

This should be the desired approach.  Although I've mentioned it on more than one occasion, I'd like to state again, for the record, that this is not really correct, in that it reflects the assumption that there's something wrong specifically with `Thread.sleep()`, which is not really the case.  As far as I can see, all blocking wait/sleep calls suffer the same problem in Android and certainly the calls to `Util.wait()` in the main thread of the `WebsocketConnection`.  The only difference about the call to `Thread.sleep()`, is that its failure is more or less certain and its results catastrophic.  Failure of the `Util.wait()` calls on the other hand depend on network conditions and will lead to rare but hard to track down loss of connection for prolonged periods.

Still, this gets most of the job done and should make the application at least usable for anyone who doesn't (care to) have a GCM-enabled device.