### PR TITLE
Replacing Thread.sleep with alarms for android devices

### DIFF
--- a/android/src/main/java/org/whispersystems/signalservice/AndroidThread.java
+++ b/android/src/main/java/org/whispersystems/signalservice/AndroidThread.java
@@ -1,0 +1,62 @@
+/**
+ * Copyright (C) 2014-2016 Open Whisper Systems
+ *
+ * Licensed according to the LICENSE file in this repository.
+ */
+
+package org.whispersystems.signalservice;
+
+import android.app.AlarmManager;
+import android.app.PendingIntent;
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+import android.content.IntentFilter;
+import android.os.Build;
+import android.os.SystemClock;
+
+import org.whispersystems.signalservice.api.util.SignalThread;
+
+public class AndroidThread extends BroadcastReceiver implements SignalThread {
+
+  public static final String SLEEP_ACTION = "org.whispersystems.signalservice.AndroidThread.SLEEP";
+
+  private AlarmManager alarmManager;
+  private PendingIntent pendingIntent;
+
+  public AndroidThread(Context context) {
+    this.pendingIntent = PendingIntent.getBroadcast(context, 0, new Intent(SLEEP_ACTION), 0);
+    alarmManager = (AlarmManager) context.getSystemService(Context.ALARM_SERVICE);
+    context.registerReceiver(this,
+            new IntentFilter(SLEEP_ACTION));
+
+  }
+
+  @Override
+  public void sleep(long millis) throws InterruptedException {
+    long wakeupTime = SystemClock.elapsedRealtime() + millis;
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+      this.alarmManager.setExactAndAllowWhileIdle(AlarmManager.ELAPSED_REALTIME_WAKEUP, wakeupTime, pendingIntent);
+    } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
+      this.alarmManager.setExact(AlarmManager.ELAPSED_REALTIME_WAKEUP, wakeupTime, pendingIntent);
+    } else {
+      this.alarmManager.set(AlarmManager.ELAPSED_REALTIME_WAKEUP, wakeupTime, pendingIntent);
+    }
+    synchronized (this) {
+      while (SystemClock.elapsedRealtime() < wakeupTime) {
+        this.wait();
+      }
+    }
+  }
+
+  @Override
+  public void onReceive(Context context, Intent intent) {
+    try {
+      synchronized (this) {
+        this.notifyAll();
+      }
+    } catch (Exception e) {
+      // nothing to do
+    }
+  }
+}

--- a/android/src/main/java/org/whispersystems/signalservice/AndroidThread.java
+++ b/android/src/main/java/org/whispersystems/signalservice/AndroidThread.java
@@ -19,17 +19,15 @@ import org.whispersystems.signalservice.api.util.SignalThread;
 
 public class AndroidThread extends BroadcastReceiver implements SignalThread {
 
-  public static final String SLEEP_ACTION = "org.whispersystems.signalservice.AndroidThread.SLEEP";
+  private static final String SLEEP_ACTION = "org.whispersystems.signalservice.AndroidThread.SLEEP";
 
-  private AlarmManager alarmManager;
-  private PendingIntent pendingIntent;
+  private final AlarmManager alarmManager;
+  private final PendingIntent pendingIntent;
 
   public AndroidThread(Context context) {
     this.pendingIntent = PendingIntent.getBroadcast(context, 0, new Intent(SLEEP_ACTION), 0);
-    alarmManager = (AlarmManager) context.getSystemService(Context.ALARM_SERVICE);
-    context.registerReceiver(this,
-            new IntentFilter(SLEEP_ACTION));
-
+    this.alarmManager = (AlarmManager) context.getSystemService(Context.ALARM_SERVICE);
+    context.registerReceiver(this, new IntentFilter(SLEEP_ACTION));
   }
 
   @Override

--- a/java/src/main/java/org/whispersystems/signalservice/api/SignalServiceMessageReceiver.java
+++ b/java/src/main/java/org/whispersystems/signalservice/api/SignalServiceMessageReceiver.java
@@ -16,11 +16,13 @@ import org.whispersystems.signalservice.api.messages.SignalServiceEnvelope;
 import org.whispersystems.signalservice.api.push.SignalServiceAddress;
 import org.whispersystems.signalservice.api.profiles.SignalServiceProfile;
 import org.whispersystems.signalservice.api.util.CredentialsProvider;
+import org.whispersystems.signalservice.api.util.SignalThread;
 import org.whispersystems.signalservice.api.websocket.ConnectivityListener;
 import org.whispersystems.signalservice.internal.configuration.SignalServiceConfiguration;
 import org.whispersystems.signalservice.internal.push.PushServiceSocket;
 import org.whispersystems.signalservice.internal.push.SignalServiceEnvelopeEntity;
 import org.whispersystems.signalservice.internal.configuration.SignalServiceUrl;
+import org.whispersystems.signalservice.internal.util.JavaThread;
 import org.whispersystems.signalservice.internal.util.StaticCredentialsProvider;
 import org.whispersystems.signalservice.internal.websocket.WebSocketConnection;
 import org.whispersystems.signalservice.internal.websocket.WebSocketEventListener;
@@ -135,9 +137,21 @@ public class SignalServiceMessageReceiver {
    * @return A SignalServiceMessagePipe for receiving Signal Service messages.
    */
   public SignalServiceMessagePipe createMessagePipe() {
+    return createMessagePipe(new JavaThread());
+  }
+
+  /**
+   * Creates a pipe for receiving SignalService messages.
+   *
+   * Callers must call {@link SignalServiceMessagePipe#shutdown()} when finished with the pipe.
+   *
+   * @return A SignalServiceMessagePipe for receiving Signal Service messages.
+   */
+  public SignalServiceMessagePipe createMessagePipe(SignalThread signalThread) {
     WebSocketConnection webSocket = new WebSocketConnection(urls.getSignalServiceUrls()[0].getUrl(),
-                                                            urls.getSignalServiceUrls()[0].getTrustStore(),
-                                                            credentialsProvider, userAgent, connectivityListener);
+            urls.getSignalServiceUrls()[0].getTrustStore(),
+            credentialsProvider, userAgent, connectivityListener,
+            signalThread);
 
     return new SignalServiceMessagePipe(webSocket, credentialsProvider);
   }

--- a/java/src/main/java/org/whispersystems/signalservice/api/util/SignalThread.java
+++ b/java/src/main/java/org/whispersystems/signalservice/api/util/SignalThread.java
@@ -1,0 +1,11 @@
+/**
+ * Copyright (C) 2014-2016 Open Whisper Systems
+ *
+ * Licensed according to the LICENSE file in this repository.
+ */
+
+package org.whispersystems.signalservice.api.util;
+
+public interface SignalThread {
+  void sleep(long millis) throws InterruptedException;
+}

--- a/java/src/main/java/org/whispersystems/signalservice/internal/util/JavaThread.java
+++ b/java/src/main/java/org/whispersystems/signalservice/internal/util/JavaThread.java
@@ -1,0 +1,16 @@
+/**
+ * Copyright (C) 2014-2016 Open Whisper Systems
+ *
+ * Licensed according to the LICENSE file in this repository.
+ */
+
+package org.whispersystems.signalservice.internal.util;
+
+import org.whispersystems.signalservice.api.util.SignalThread;
+
+public class JavaThread implements SignalThread {
+  @Override
+  public void sleep(long millis) throws InterruptedException {
+    Thread.sleep(millis);
+  }
+}


### PR DESCRIPTION
First: This is nearly the same as #53 submitted by dpapavas. I had finished it before I saw that there is an other merge request with nearly the same code open. If you are happy with #53 or just don't want to spend more time on this, feel free to stop reading here and close it without comment.

This is just a resubmission of #52 with the changes @moxie0 has specified. It had been only minor change requests, so it should match all needs now. I ran this code for several weeks and everything is stable.

It's a few lines less than #53 and as it reuses the PendingIntent and not creating it every minute it might be a tiny bit more efficient. To use the new behaviour only one line needs to be changed in SignalAndroid as requested.