### PR TITLE
Increased maximum buffer size in network file transfers from 4096 byt…

### DIFF
--- a/java/src/main/java/org/whispersystems/signalservice/internal/push/PushServiceSocket.java
+++ b/java/src/main/java/org/whispersystems/signalservice/internal/push/PushServiceSocket.java
@@ -469,7 +469,7 @@ public class PushServiceSocket {
 
       OutputStream output        = new FileOutputStream(localDestination);
       InputStream  input         = connection.getInputStream();
-      byte[]       buffer        = new byte[4096];
+      byte[]       buffer        = new byte[32768];
       int          contentLength = connection.getContentLength();
       int         read,totalRead = 0;
 
@@ -521,7 +521,7 @@ public class PushServiceSocket {
 
     try {
       DigestingOutputStream out    = outputStreamFactory.createFor(connection.getOutputStream());
-      byte[]                buffer = new byte[4096];
+      byte[]                buffer = new byte[32768];
       int            read, written = 0;
 
       while ((read = data.read(buffer)) != -1) {
@@ -582,7 +582,7 @@ public class PushServiceSocket {
 
         InputStream  in     = body.byteStream();
         OutputStream out    = new FileOutputStream(destination);
-        byte[]       buffer = new byte[4096];
+        byte[]       buffer = new byte[32768];
 
         int read, totalRead = 0;
 


### PR DESCRIPTION
…es to 32768 bytes for better performance to resolve #56.

The following comparison also suggests that 32768 bytes is optimal buffer size for multiple android devices: https://stackoverflow.com/questions/10143731/android-optimal-buffer-size