### PR TITLE
Use correct timestamp in Note to self envelopes

### DIFF
--- a/java/src/main/java/org/whispersystems/signalservice/api/SignalServiceMessageSender.java
+++ b/java/src/main/java/org/whispersystems/signalservice/api/SignalServiceMessageSender.java
@@ -290,7 +290,9 @@ public class SignalServiceMessageSender {
       throw new IOException("Unsupported sync message!");
     }
 
-    sendMessage(localAddress, Optional.<UnidentifiedAccess>absent(), System.currentTimeMillis(), content, false);
+    sendMessage(localAddress, Optional.<UnidentifiedAccess>absent(),
+            message.getSent().isPresent() ? message.getSent().get().getTimestamp() : System.currentTimeMillis(),
+            content, false);
   }
 
   public void setSoTimeoutMillis(long soTimeoutMillis) {


### PR DESCRIPTION
When sending a SentTranscript sync message manually (as done for note to
self messages), the timestamp of the envelope is set to the current time
instead of the transcript message's timestamp.

This causes these sent message to be rejected when received by
libsignal-service-java:
```
org.whispersystems.libsignal.InvalidMessageException:
Timestamps don't match: 1553373769631 vs 1553373769692 (ProtocolInvalidMessageException)
```

It looks like Signal-Desktop doesn't do this validation (which is probably
a bug by itself), so the timestamp mismatch can't be observed when sending
messages from Signal-Android to Signal-Desktop. The issue is only noticable
when an application using libsignal-service-java is linked to another one using libsignal-service-java.

Noticed here: AsamK/signal-cli#196