### PR TITLE
fixing RealtimeSleepTimer to work in concurrent threads

### DIFF
--- a/android/src/main/java/org/whispersystems/signalservice/api/util/RealtimeSleepTimer.java
+++ b/android/src/main/java/org/whispersystems/signalservice/api/util/RealtimeSleepTimer.java
@@ -10,9 +10,7 @@ import android.os.Build;
 import android.os.SystemClock;
 import android.util.Log;
 
-import org.whispersystems.signalservice.api.util.SleepTimer;
-
-import java.util.concurrent.TimeUnit;
+import java.util.concurrent.ConcurrentLinkedQueue;
 
 /**
  * A sleep timer that is based on elapsed realtime, so
@@ -21,24 +19,29 @@ import java.util.concurrent.TimeUnit;
  */
 public class RealtimeSleepTimer implements SleepTimer {
   private static final String TAG = RealtimeSleepTimer.class.getSimpleName();
+  private static ConcurrentLinkedQueue<Integer> actionIdList = new ConcurrentLinkedQueue<>();
 
-  private final AlarmReceiver alarmReceiver;
   private final Context context;
 
   public RealtimeSleepTimer(Context context) {
     this.context = context;
-    alarmReceiver = new RealtimeSleepTimer.AlarmReceiver();
   }
 
   @Override
   public void sleep(long millis) {
-    context.registerReceiver(alarmReceiver,
-                             new IntentFilter(AlarmReceiver.WAKE_UP_THREAD_ACTION));
+    final AlarmReceiver alarmReceiver = new RealtimeSleepTimer.AlarmReceiver();
+    int actionId = 0;
+    while (!actionIdList.add(actionId)){
+      actionId++;
+    }
+    try {
+      context.registerReceiver(alarmReceiver,
+             new IntentFilter(AlarmReceiver.WAKE_UP_THREAD_ACTION + "." + actionId));
 
-    final long startTime = System.currentTimeMillis();
-    alarmReceiver.setAlarm(millis);
+      final long startTime = System.currentTimeMillis();
+      alarmReceiver.setAlarm(millis, AlarmReceiver.WAKE_UP_THREAD_ACTION + "." + actionId);
 
-    while (System.currentTimeMillis() - startTime < millis) {
+      while (System.currentTimeMillis() - startTime < millis) {
         try {
           synchronized (this) {
             wait(millis - System.currentTimeMillis() + startTime);
@@ -46,16 +49,20 @@ public class RealtimeSleepTimer implements SleepTimer {
         } catch (InterruptedException e) {
           Log.w(TAG, e);
         }
+      }
+      context.unregisterReceiver(alarmReceiver);
+    } catch(Exception e) {
+      Log.w(TAG, "Exception during sleep ...",e);
+    }finally {
+      actionIdList.remove(actionId);
     }
-
-    context.unregisterReceiver(alarmReceiver);
   }
 
   private class AlarmReceiver extends BroadcastReceiver {
     private static final String WAKE_UP_THREAD_ACTION = "org.whispersystems.signalservice.api.util.RealtimeSleepTimer.AlarmReceiver.WAKE_UP_THREAD";
 
-    private void setAlarm(long millis) {
-      final Intent        intent        = new Intent(WAKE_UP_THREAD_ACTION);
+    private void setAlarm(long millis, String action) {
+      final Intent        intent        = new Intent(action);
       final PendingIntent pendingIntent = PendingIntent.getBroadcast(context, 0, intent, 0);
       final AlarmManager  alarmManager  = (AlarmManager)context.getSystemService(Context.ALARM_SERVICE);
 

--- a/android/src/main/java/org/whispersystems/signalservice/api/util/RealtimeSleepTimer.java
+++ b/android/src/main/java/org/whispersystems/signalservice/api/util/RealtimeSleepTimer.java
@@ -10,7 +10,7 @@ import android.os.Build;
 import android.os.SystemClock;
 import android.util.Log;
 
-import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.ConcurrentSkipListSet;
 
 /**
  * A sleep timer that is based on elapsed realtime, so
@@ -19,7 +19,7 @@ import java.util.concurrent.ConcurrentLinkedQueue;
  */
 public class RealtimeSleepTimer implements SleepTimer {
   private static final String TAG = RealtimeSleepTimer.class.getSimpleName();
-  private static ConcurrentLinkedQueue<Integer> actionIdList = new ConcurrentLinkedQueue<>();
+  private static ConcurrentSkipListSet<Integer> actionIdList = new ConcurrentSkipListSet<>();
 
   private final Context context;
 


### PR DESCRIPTION
The method RealtimeSleepTimer.sleep() does not work when called in multiple threads. This was not a problem when it was introduced, but since SealedSender there are two websocketConnetions, which both have a KeepAlive-Thread using RealtimeSleepTimer.sleep() concurrently, which leads to an Exception in many (perhaps all) gcm free devices every 55 seconds. This leads to several problems, including high energy usage or unreliable connection.

The exception is:
`WebSocketConnection: java.lang.IllegalArgumentException: Receiver not registered: org.whispersystems.signalservice.api.util.RealtimeSleepTimer$AlarmReceiver@ab5dd6e`

This exception is referenced in several issues of Signal-Android:
[signalapp/Signal-Android#8658](https://github.com/signalapp/Signal-Android/issues/8658)
[signalapp/Signal-Android#8519](https://github.com/signalapp/Signal-Android/issues/8519)
[signalapp/Signal-Android#8402](https://github.com/signalapp/Signal-Android/issues/8402)
[signalapp/Signal-Android#8217](https://github.com/signalapp/Signal-Android/issues/8217)
 
This patch resolves this exception.

There is already another pull request by @dpapavas (#62), which among other things tries to address this problem. I made a seperate request for two reasons:

1.  I think @dpapavas tries to patch too many things at once, so the patch is difficult to apply because there are a lot of changes.
2.  Although #62 will solve the problem in the current situation, I am quite sure that it will not work as soon as there are more threads with different timings calling RealtimeSleepTimer.sleep(), so my solution should be more general and permanent.

If you plan to merge #62 in near future, you can close this request here as it is not needed. For gcm free users this is a very urgent problem, so it would be great if you could merge #62 or this patch here soon. I tried to stay as close as possible to the original code to make merging easy.

I have provided a compiled version of this patch for testing:
https://github.com/theBoatman/fixing-signal/blob/master/Signal-website-release-4.36.2-sleepfix.apk

There is also a forum thread discussing the problem:
https://community.signalusers.org/t/very-high-battery-drain-on-4-34-8-without-google-play-services/6536

