### PR TITLE
Increase timeout to support unreliable networks

### DIFF
--- a/java/src/main/java/org/whispersystems/signalservice/internal/push/PushServiceSocket.java
+++ b/java/src/main/java/org/whispersystems/signalservice/internal/push/PushServiceSocket.java
@@ -143,7 +143,7 @@ public class PushServiceSocket {
   private static final Map<String, String> NO_HEADERS = Collections.emptyMap();
   private static final ResponseCodeHandler NO_HANDLER = new EmptyResponseCodeHandler();
 
-  private       long      soTimeoutMillis = TimeUnit.SECONDS.toMillis(30);
+  private       long      soTimeoutMillis = TimeUnit.SECONDS.toMillis(120);
   private final Set<Call> connections     = new HashSet<>();
 
   private final ServiceConnectionHolder[]  serviceClients;


### PR DESCRIPTION
Uploading attachments over an unreliable mobile network often fails for me due to this timeout, hence I propose it is increased.