### PR TITLE
Fixes signalapp#8901

### DIFF
--- a/java/src/main/java/org/whispersystems/signalservice/internal/push/PushServiceSocket.java
+++ b/java/src/main/java/org/whispersystems/signalservice/internal/push/PushServiceSocket.java
@@ -426,7 +426,7 @@ public class PushServiceSocket {
   public void retrieveAttachment(long attachmentId, File destination, int maxSizeBytes, ProgressListener listener)
       throws NonSuccessfulResponseCodeException, PushNetworkException
   {
-    downloadFromCdn(destination, String.format(ATTACHMENT_DOWNLOAD_PATH, attachmentId), maxSizeBytes, listener);
+    downloadFromCdn(destination, String.format(Locale.ENGLISH, ATTACHMENT_DOWNLOAD_PATH, attachmentId), maxSizeBytes, listener);
   }
 
   public void retrieveSticker(File destination, byte[] packId, int stickerId)


### PR DESCRIPTION
Fixes: [signalapp#8901 ](https://github.com/signalapp/Signal-Android/issues/8901). The problem caused from `String.format(...)` that changes the number format to system locale (e.g. for Arabic the link would be like `https://cdn.signal.org/attachments/١٢٣٤٥٦٧٨٩`) and this will cause wrong link.